### PR TITLE
Update boost pinning to 1.62.*

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 338b311df338950ace79a8d26ffae17f3425bdc56cb8b36b620a69f5841b64f0
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
   detect_binary_files_with_prefix: true
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,13 +17,13 @@ build:
 requirements:
   build:
     - cmake
-    - boost 1.61.*
+    - boost 1.62.*
     - jasper
     - libpng >=1.6.23,<1.7
     - libnetcdf 4.4.*
     - perl
   run:
-    - boost 1.61.*
+    - boost 1.62.*
     - jasper
     - libpng >=1.6.23,<1.7
     - libnetcdf 4.4.*


### PR DESCRIPTION
`conda-forge` is using a default pinning of boost to 1.62.*.  This update the recipe to use this version.