### PR TITLE
MNT: bump version to 2.1.0, reinstantiate gts tests

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,7 +2,6 @@
 
 if [[ $(uname) == Darwin ]]; then
   export LIBRARY_SEARCH_VAR=DYLD_FALLBACK_LIBRARY_PATH
-  ctestarg="-E gts"
 elif [[ $(uname) == Linux ]]; then
   export LIBRARY_SEARCH_VAR=LD_LIBRARY_PATH
 fi
@@ -25,5 +24,5 @@ cmake $src_dir \
 make
 export ECCODES_TEST_VERBOSE_OUTPUT=1
 eval ${LIBRARY_SEARCH_VAR}=$PREFIX/lib
-ctest $ctestarg
+ctest
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.0.2" %}
+{% set version = "2.1.0" %}
 
 package:
   name: eccodes
@@ -7,10 +7,10 @@ package:
 source:
   url: https://software.ecmwf.int/wiki/download/attachments/45757960/eccodes-{{ version }}-Source.tar.gz
   fn: eccodes-{{ version }}-Source.tar.gz
-  sha256: e0368dd4dbd85edfd6a9fbe442a10fea611a773550f7ea7ce1f56ee0b340f6cb
+  sha256: e7382b06d99e9f6558751c888403181cbbac95ea51275c7ff8d41c15c2ccf554
 
 build:
-  number: 1
+  number: 0
   skip: true  # [win]
   detect_binary_files_with_prefix: true
 
@@ -37,7 +37,7 @@ about:
   home: https://software.ecmwf.int/wiki/display/ECC/ecCodes+Home
   license: Apache 2.0
   license_family: Apache
-  summary: ECMWF ecCodes Copyright 2005-2016 ECMWF.
+  summary: ECMWF ecCodes Copyright 2005-2017 ECMWF.
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
see [eccodes-2.1.0 release notes](https://software.ecmwf.int/wiki/display/ECC/ecCodes+version+2.1.0+released)