### PR TITLE
Enabling Fortran in ecCodes.

### DIFF
--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -1,5 +1,3 @@
-boost:
-- 1.67.0
 c_compiler:
 - toolchain_c
 channel_sources:
@@ -21,8 +19,6 @@ libnetcdf:
 libpng:
 - 1.6.34
 pin_run_as_build:
-  boost:
-    max_pin: x.x.x
   hdf5:
     max_pin: x.x.x
   jasper:

--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -2,8 +2,14 @@ boost:
 - 1.67.0
 c_compiler:
 - toolchain_c
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
 cxx_compiler:
 - toolchain_cxx
+docker_image:
+- condaforge/linux-anvil
 fortran_compiler:
 - toolchain_fort
 hdf5:

--- a/.ci_support/osx_.yaml
+++ b/.ci_support/osx_.yaml
@@ -4,6 +4,10 @@ boost:
 - 1.67.0
 c_compiler:
 - toolchain_c
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
 cxx_compiler:
 - toolchain_cxx
 fortran_compiler:

--- a/.ci_support/osx_.yaml
+++ b/.ci_support/osx_.yaml
@@ -1,7 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
-boost:
-- 1.67.0
 c_compiler:
 - toolchain_c
 channel_sources:
@@ -25,8 +23,6 @@ macos_machine:
 macos_min_version:
 - '10.9'
 pin_run_as_build:
-  boost:
-    max_pin: x.x.x
   hdf5:
     max_pin: x.x.x
   jasper:

--- a/.circleci/build_steps.sh
+++ b/.circleci/build_steps.sh
@@ -7,27 +7,34 @@
 
 set -xeuo pipefail
 export PYTHONUNBUFFERED=1
+export FEEDSTOCK_ROOT=/home/conda/feedstock_root
+export RECIPE_ROOT=/home/conda/recipe_root
+export CI_SUPPORT=/home/conda/feedstock_root/.ci_support
+export CONFIG_FILE="${CI_SUPPORT}/${CONFIG}.yaml"
 
 cat >~/.condarc <<CONDARC
-
-channels:
- - conda-forge
- - defaults
 
 conda-build:
  root-dir: /home/conda/feedstock_root/build_artifacts
 
-show_channel_urls: true
-
 CONDARC
+
+conda install --yes --quiet conda-forge::conda-forge-ci-setup=2 conda-build
+
+# set up the condarc
+setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 # A lock sometimes occurs with incomplete builds. The lock file is stored in build_artifacts.
 conda clean --lock
 
-conda install --yes --quiet conda-forge-ci-setup=1 conda-build
 source run_conda_forge_build_setup
 
-conda build /home/conda/recipe_root -m /home/conda/feedstock_root/.ci_support/${CONFIG}.yaml --quiet
-upload_or_check_non_existence /home/conda/recipe_root conda-forge --channel=main -m /home/conda/feedstock_root/.ci_support/${CONFIG}.yaml
+# make the build number clobber
+make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+
+conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"  --quiet
+
+upload_package "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 touch "/home/conda/feedstock_root/build_artifacts/conda-forge-build-done-${CONFIG}"

--- a/.circleci/fast_finish_ci_pr_build.sh
+++ b/.circleci/fast_finish_ci_pr_build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-curl https://raw.githubusercontent.com/conda-forge/conda-forge-ci-setup-feedstock/master/recipe/ff_ci_pr_build.py | \
+curl https://raw.githubusercontent.com/conda-forge/conda-forge-ci-setup-feedstock/branch2.0/recipe/conda_forge_ci_setup/ff_ci_pr_build.py | \
      python - -v --ci "circle" "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}" "${CIRCLE_BUILD_NUM}" "${CIRCLE_PR_NUMBER}"

--- a/.circleci/run_docker_build.sh
+++ b/.circleci/run_docker_build.sh
@@ -8,7 +8,7 @@
 set -xeuo pipefail
 
 FEEDSTOCK_ROOT=$(cd "$(dirname "$0")/.."; pwd;)
-RECIPE_ROOT=$FEEDSTOCK_ROOT/recipe
+RECIPE_ROOT="${FEEDSTOCK_ROOT}/recipe"
 
 docker info
 
@@ -29,6 +29,9 @@ if [ -z "$CONFIG" ]; then
     exit 1
 fi
 
+pip install shyaml
+DOCKER_IMAGE=$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 condaforge/linux-anvil )
+
 mkdir -p "$ARTIFACTS"
 DONE_CANARY="$ARTIFACTS/conda-forge-build-done-${CONFIG}"
 rm -f "$DONE_CANARY"
@@ -39,7 +42,7 @@ docker run -it \
            -e CONFIG \
            -e BINSTAR_TOKEN \
            -e HOST_USER_ID \
-           condaforge/linux-anvil \
+           $DOCKER_IMAGE \
            bash \
            /home/conda/feedstock_root/.circleci/build_steps.sh
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ Checklist
 * [ ] Used a fork of the feedstock to propose changes
 * [ ] Bumped the build number (if the version is unchanged)
 * [ ] Reset the build number to `0` (if the version changed)
-* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
+* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
 * [ ] Ensured the license file is being packaged.
 
 <!--

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
 before_install:
     # Fast finish the PR.
     - |
-      (curl https://raw.githubusercontent.com/conda-forge/conda-forge-ci-setup-feedstock/master/recipe/ff_ci_pr_build.py | \
+      (curl https://raw.githubusercontent.com/conda-forge/conda-forge-ci-setup-feedstock/branch2.0/recipe/conda_forge_ci_setup/ff_ci_pr_build.py | \
           python - -v --ci "travis" "${TRAVIS_REPO_SLUG}" "${TRAVIS_BUILD_NUMBER}" "${TRAVIS_PULL_REQUEST}") || exit 1
 
     # Remove homebrew.
@@ -46,14 +46,18 @@ install:
       echo ""
       echo "Configuring conda."
       source /Users/travis/miniconda3/bin/activate root
-      conda config --remove channels defaults
-      conda config --add channels defaults
-      conda config --add channels conda-forge
-      conda config --set show_channel_urls true
-      conda install --yes --quiet conda-forge-ci-setup=1
+
+      conda install --yes --quiet conda-forge::conda-forge-ci-setup=2
+      setup_conda_rc ./ ./recipe ./.ci_support/${CONFIG}.yaml
+
       source run_conda_forge_build_setup
 
-script:
-  - conda build ./recipe -m ./.ci_support/${CONFIG}.yaml
+    # compiler cleanup
+    - |
+      mangle_compiler ./ ./recipe ./.ci_support/${CONFIG}.yaml
 
-  - upload_or_check_non_existence ./recipe conda-forge --channel=main -m ./.ci_support/${CONFIG}.yaml
+script:
+  # generate the build number clobber
+  - make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
+  - conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
+  - upload_package ./ ./recipe ./.ci_support/${CONFIG}.yaml

--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ for each of the installable packages. Such a repository is known as a *feedstock
 A feedstock is made up of a conda recipe (the instructions on what and how to build
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
-[CircleCI](https://circleci.com/), [AppVeyor](http://www.appveyor.com/)
+[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
 and [TravisCI](https://travis-ci.org/) it is possible to build and upload installable
 packages to the [conda-forge](https://anaconda.org/conda-forge)
-[Anaconda-Cloud](http://docs.anaconda.org/) channel for Linux, Windows and OSX respectively.
+[Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
 
 To manage the continuous integration and simplify feedstock maintenance
-[conda-smithy](http://github.com/conda-forge/conda-smithy) has been developed.
+[conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
@@ -100,7 +100,7 @@ build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:
  * If the version of a package **is not** being increased, please add or increase
-   the [``build/number``](http://conda.pydata.org/docs/building/meta-yaml.html#build-number-and-string).
+   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string).
  * If the version of a package **is** being increased, please remember to return
-   the [``build/number``](http://conda.pydata.org/docs/building/meta-yaml.html#build-number-and-string)
+   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string)
    back to 0.

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -46,7 +46,7 @@ cmake $src_dir \
          -DENABLE_NETCDF=1 \
          -DENABLE_PNG=1 \
          -DENABLE_PYTHON=0 \
-         -DENABLE_FORTRAN=0
+         -DENABLE_FORTRAN=1
 
 make -j $CPU_COUNT >> $BUILD_OUTPUT 2>&1
 export ECCODES_TEST_VERBOSE_OUTPUT=1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,6 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
-    - boost
     - jasper
     - libpng
     - libnetcdf

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.8.0" %}
+{% set version = "2.8.2" %}
 
 package:
   name: eccodes
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://software.ecmwf.int/wiki/download/attachments/45757960/eccodes-{{ version }}-Source.tar.gz
-  sha256: e0ba24c27cdd8133670fa3ea32be951d54030f2b880cacc9a9d87d9dbf372e1b
+  sha256: 36e6e73d654027b31c323b0eddd15e4d1f011ad81e79e9c71146ba96293d712a
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 36e6e73d654027b31c323b0eddd15e4d1f011ad81e79e9c71146ba96293d712a
 
 build:
-  number: 1
+  number: 0
   skip: true  # [win]
   detect_binary_files_with_prefix: true
 


### PR DESCRIPTION
Enabling the build of ecCodes with Fortran bindings.
Also upping the ecCode patch level to 2.8.2.

Checklist
* [x] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [ ] Ensured the license file is being packaged.

Please note the Travis-CI passed.

This will fix #48 . 