### PR TITLE
 Acknowledge zlib dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: ff04eb1fa4c363438bbbd6d75b66b4237c7397f8b0bd311d9243b6b2dcfc09d6
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   detect_binary_files_with_prefix: true
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,11 +25,13 @@ requirements:
     - libpng
     - libnetcdf
     - hdf5
+    - zlib
   run:
     - jasper
     - libpng
     - libnetcdf
     - hdf5
+    - zlib
 
 test:
   commands:


### PR DESCRIPTION
Downstream from ecCodes we have problems linking with ecCodes because a zlib in ecCodes (temporary) build is referred to. It seems to be fixed by making ecCodes link publicly with zlib.

Errors in Magics is:
make[2]: *** No rule to make target `/home/conda/feedstock_root/build_artifacts/eccodes_1538059641473/_build_env/lib/libz.so', needed by `lib/libMagPlus.so'.  Stop.

Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [-] Reset the build number to `0` (if the version changed)
* [-] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ x] Ensured the license file is being packaged.
