### PR TITLE
WIP: Fix runtime search path errors

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,11 +16,12 @@ build:
     - vc14  # [win and py>=35]
 
 requirements:
-  host:
-    - cmake
+  build:
     - {{ compiler('fortran') }}  # [not win]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+  host:
+    - cmake
     - m2-bash  # [win]
     - m2-findutils  # [win]
     - m2-coreutils  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,14 +9,14 @@ source:
   sha256: 455c05badd3554d6f67dff713f6991164b43ed835e1b8a9da7b728499f22932d
 
 build:
-  number: 1001
+  number: 1002
   skip: true  # [win and vc<14]
   detect_binary_files_with_prefix: true
   features:
     - vc14  # [win and py>=35]
 
 requirements:
-  build:
+  host:
     - cmake
     - {{ compiler('fortran') }}  # [not win]
     - {{ compiler('c') }}
@@ -28,7 +28,6 @@ requirements:
     - m2-sed  # [win]
     - m2-gawk  # [win]
     - m2-diffutils  # [win]
-  host:
     - perl  # [not win]
     - m2-perl  # [win]
     - jasper  # [not win]


### PR DESCRIPTION
This aims to fix the following warning, which is causing ecCodes to not
function correctly on Linux (and probably Mac).

```
CMake Warning at cmake/ecbuild_add_executable.cmake:205 (add_executable):
  Cannot generate a safe runtime search path for target grib_to_netcdf
  because files in some directories may conflict with libraries in implicit
  directories:

    runtime library [libz.so.1] in /home/conda/feedstock_root/build_artifacts/eccodes_1548176342315/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pla/lib may be hidden by files in:
      /home/conda/feedstock_root/build_artifacts/eccodes_1548176342315/_build_env/lib

  Some of these libraries may not be found correctly.
```

The problem surfaces when we try to build another library (e.g. Magics)
using conda-forgee built ecCodes. We try to include a target from the
original (and now non-existant) ecCodes build path.

```
make[2]: *** No rule to make target `/home/conda/feedstock_root/build_artifacts/eccodes_1548107111590/_build_env/lib/libz.so', needed by `lib/libMagPlus.so'.  Stop.
```

Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.
