### PR TITLE
Fix leaked build environment

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -63,7 +63,11 @@ fi
 make install >> $BUILD_OUTPUT 2>&1
 
 # Replace any leaked build env
-find $PREFIX -type f -print0 | xargs -0 sed -i "s@${BUILD_PREFIX}@${PREFIX}@g" >> $BUILD_OUTPUT 2>&1
+if [[ $(uname) == Linux ]]; then
+    find $PREFIX/include -type f -print0 | xargs -0 sed -i "s@${BUILD_PREFIX}@${PREFIX}@g" >> $BUILD_OUTPUT 2>&1
+    find $PREFIX/lib/pkgconfig -type f -print0 | xargs -0 sed -i "s@${BUILD_PREFIX}@${PREFIX}@g" >> $BUILD_OUTPUT 2>&1
+    find $PREFIX/share/eccodes/cmake -type f -print0 | xargs -0 sed -i "s@${BUILD_PREFIX}@${PREFIX}@g" >> $BUILD_OUTPUT 2>&1
+fi
 
 # The build finished without returning an error so dump a tail of the output.
 dump_output

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -13,6 +13,12 @@ fi
 
 touch $BUILD_OUTPUT
 
+if [[ $(uname) == Linux ]]; then
+    export CC=$(basename ${CC})
+    export CXX=$(basename ${CXX})
+    export FC=$(basename ${FC})
+fi
+
 dump_output() {
    echo Tailing the last 500 lines of output:
    tail -500 $BUILD_OUTPUT

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -73,6 +73,9 @@ if [[ $(uname) == Linux ]]; then
     find $PREFIX/include -type f -print0 | xargs -0 sed -i "s@${BUILD_PREFIX}@${PREFIX}@g" >> $BUILD_OUTPUT 2>&1
     find $PREFIX/lib/pkgconfig -type f -print0 | xargs -0 sed -i "s@${BUILD_PREFIX}@${PREFIX}@g" >> $BUILD_OUTPUT 2>&1
     find $PREFIX/share/eccodes/cmake -type f -print0 | xargs -0 sed -i "s@${BUILD_PREFIX}@${PREFIX}@g" >> $BUILD_OUTPUT 2>&1
+
+    find $PREFIX/bin -type f | xargs sed -i "s@${BUILD_PREFIX}/bin/${CC}@${CC}@g" >> $BUILD_OUTPUT 2>&1
+    find $PREFIX/lib -type f | xargs sed -i "s@${BUILD_PREFIX}/bin/${CC}@${CC}@g" >> $BUILD_OUTPUT 2>&1
 fi
 
 # The build finished without returning an error so dump a tail of the output.

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -62,6 +62,9 @@ ctest -j $CPU_COUNT >> $BUILD_OUTPUT 2>&1
 fi
 make install >> $BUILD_OUTPUT 2>&1
 
+# Replace any leaked build env
+find $PREFIX -type f -print0 | xargs -0 sed -i "s@${BUILD_PREFIX}@${PREFIX}@g" >> $BUILD_OUTPUT 2>&1
+
 # The build finished without returning an error so dump a tail of the output.
 dump_output
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 455c05badd3554d6f67dff713f6991164b43ed835e1b8a9da7b728499f22932d
 
 build:
-  number: 1002
+  number: 1003
   skip: true  # [win and vc<14]
   detect_binary_files_with_prefix: true
   features:


### PR DESCRIPTION
Following on from https://github.com/conda-forge/eccodes-feedstock/pull/62

The current build still depends on BUILD_PATH:
```
-- Found HDF5: $PREFIX/lib/libhdf5.so;$BUILD_PREFIX/x86_64-conda_cos6-linux-gnu/sysroot/usr/lib/librt.so;$BUILD_PREFIX/x86_64-conda_cos6-linux-gnu/sysroot/usr/lib/libpthread.so;$PREFIX/lib/libz.so;$BUILD_PREFIX/x86_64-conda_cos6-linux-gnu/sysroot/usr/lib/libdl.so;$BUILD_PREFIX/x86_64-conda_cos6-linux-gnu/sysroot/usr/lib/libm.so (found version "1.10.4")  
```
```
--  CMath 
--       libs     : [$BUILD_PREFIX/x86_64-conda_cos6-linux-gnu/sysroot/usr/lib/libm.so]
```

Moving the compilers from 'build' to 'host' seems to fix the HDF5 paths but means we can't find cmath. The build later fails because we can't find libm.so. Try installing openlibm to fix it.

Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

