### PR TITLE
Remove pins of conda-build and conda

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -37,7 +37,7 @@ install:
 
     # Configure the VM.
     # Tell conda we want an updated version of conda-forge-ci-setup and conda-build
-    - cmd: conda.exe install -n root -c conda-forge --quiet --yes conda-forge-ci-setup=2 conda-build=3.15 conda=4.5.12
+    - cmd: conda.exe install -n root -c conda-forge --quiet --yes conda-forge-ci-setup=2 conda-build
     - cmd: setup_conda_rc .\ .\recipe .\.ci_support\%CONFIG%.yaml
     - cmd: run_conda_forge_build_setup
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -23,7 +23,7 @@ if errorlevel 1 exit 1
 :: so tests can find eccodes.dll
 set PATH=%PATH%;%SRC_DIR%\build\bin
 
-ctest
+ctest --output-on-failure
 if errorlevel 1 exit 1
 
 nmake install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -64,7 +64,7 @@ make -j $CPU_COUNT VERBOSE=1 >> $BUILD_OUTPUT 2>&1
 export ECCODES_TEST_VERBOSE_OUTPUT=1
 eval ${LIBRARY_SEARCH_VAR}=$PREFIX/lib
 if [[ $(uname) == Linux ]]; then
-ctest -j $CPU_COUNT >> $BUILD_OUTPUT 2>&1
+ctest --output-on-failure -j $CPU_COUNT >> $BUILD_OUTPUT 2>&1
 fi
 make install >> $BUILD_OUTPUT 2>&1
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 455c05badd3554d6f67dff713f6991164b43ed835e1b8a9da7b728499f22932d
 
 build:
-  number: 1006
+  number: 1007
   skip: true  # [win and vc<14]
   detect_binary_files_with_prefix: true
   features:


### PR DESCRIPTION
Our symlink woes should now be fixed in the latest version of conda-build

See https://github.com/conda-forge/eccodes-feedstock/issues/67

Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

