### PR TITLE
Rebuild & re-render

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,7 +23,7 @@ install:
     # If there is a newer build queued for the same PR, cancel this one.
     - cmd: |
         powershell -Command "(New-Object Net.WebClient).DownloadFile('https://raw.githubusercontent.com/conda-forge/conda-forge-ci-setup-feedstock/master/recipe/conda_forge_ci_setup/ff_ci_pr_build.py', 'ff_ci_pr_build.py')"
-        ff_ci_pr_build -v --ci "appveyor" "%APPVEYOR_ACCOUNT_NAME%/%APPVEYOR_PROJECT_SLUG%" "%APPVEYOR_BUILD_NUMBER%" "%APPVEYOR_PULL_REQUEST_NUMBER%"
+        "%CONDA_INSTALL_LOCN%\python.exe" ff_ci_pr_build.py -v --ci "appveyor" "%APPVEYOR_ACCOUNT_NAME%/%APPVEYOR_PROJECT_SLUG%" "%APPVEYOR_BUILD_NUMBER%" "%APPVEYOR_PULL_REQUEST_NUMBER%"
         del ff_ci_pr_build.py
 
     # Cygwin's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -3,7 +3,7 @@
 # -*- mode: yaml -*-
 
 jobs:
-- job: linux_64
+- job: linux
   pool:
     vmImage: ubuntu-16.04
   timeoutInMinutes: 240
@@ -29,3 +29,5 @@ jobs:
 
   - script: .azure-pipelines/run_docker_build.sh
     displayName: Run docker build
+    env:
+      BINSTAR_TOKEN: $(BINSTAR_TOKEN)

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -3,7 +3,7 @@
 # -*- mode: yaml -*-
 
 jobs:
-- job: osx_64
+- job: osx
   pool:
     vmImage: macOS-10.13
   timeoutInMinutes: 240
@@ -81,4 +81,6 @@ jobs:
       set -x -e
       upload_package ./ ./recipe ./.ci_support/${CONFIG}.yaml
     displayName: Upload recipe
+    env:
+      BINSTAR_TOKEN: $(BINSTAR_TOKEN)
     condition: not(eq(variables['UPLOAD_PACKAGES'], 'False'))

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -3,7 +3,7 @@
 # -*- mode: yaml -*-
 
 jobs:
-- job: win_64
+- job: win
   pool:
     vmImage: vs2017-win2016
   timeoutInMinutes: 240
@@ -73,20 +73,29 @@ jobs:
       displayName: conda-forge build setup
     
 
+    - script: |
+        rmdir C:\strawberry /s /q
+      continueOnError: true
+      displayName: remove strawberryperl
+
     # Special cased version setting some more things!
     - script: |
-        conda.exe build recipe -m .ci_support\%CONFIG%.yaml --quiet
+        conda.exe build recipe -m .ci_support\%CONFIG%.yaml
       displayName: Build recipe (vs2008)
-      env: {
-        VS90COMNTOOLS: "C:\\Program Files (x86)\\Common Files\\Microsoft\\Visual C++ for Python\\9.0\\VC\\bin",
-      }
+      env:
+        VS90COMNTOOLS: "C:\\Program Files (x86)\\Common Files\\Microsoft\\Visual C++ for Python\\9.0\\VC\\bin"
+        PYTHONUNBUFFERED: 1
       condition: contains(variables['CONFIG'], 'vs2008')
 
     - script: |
-        conda.exe build recipe -m .ci_support\%CONFIG%.yaml --quiet
+        conda.exe build recipe -m .ci_support\%CONFIG%.yaml
       displayName: Build recipe
+      env:
+        PYTHONUNBUFFERED: 1
       condition: not(contains(variables['CONFIG'], 'vs2008'))
 
     - script: |
         upload_package .\ .\recipe .ci_support\%CONFIG%.yaml
+      env:
+        BINSTAR_TOKEN: $(BINSTAR_TOKEN)
       condition: not(eq(variables['UPLOAD_PACKAGES'], 'False'))

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Feedstock Maintainers
 =====================
 
 * [@StephanSiemen](https://github.com/StephanSiemen/)
+* [@dtip](https://github.com/dtip/)
 * [@kmuehlbauer](https://github.com/kmuehlbauer/)
 * [@kynan](https://github.com/kynan/)
 * [@ocefpaf](https://github.com/ocefpaf/)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,3 +64,4 @@ extra:
     - ocefpaf
     - pelson
     - StephanSiemen
+    - dtip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: f75ae5ce9e543622e8e40c3037619f8d9e6542c902933adb371bac82aee91367
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win and vc<14]
   detect_binary_files_with_prefix: true
   features:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,13 +31,13 @@ requirements:
     - m2-diffutils  # [win]
     - perl  # [not win]
     - m2-perl  # [win]
-    - jasper=1.900.31  # [not win]
+    - jasper=1.900.1  # [not win]
     - libpng  # [not win]
     - libnetcdf
     - libaec  # [not win]
     - hdf5
   run:
-    - jasper  # [not win]
+    - jasper=1.900.1  # [not win]
     - libpng  # [not win]
     - libnetcdf
     - libaec  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - m2-diffutils  # [win]
     - perl  # [not win]
     - m2-perl  # [win]
-    - jasper  # [not win]
+    - jasper=1.900.31  # [not win]
     - libpng  # [not win]
     - libnetcdf
     - libaec  # [not win]


### PR DESCRIPTION
The latest version of Jasper seems to have re-named libjasper.so.1 to libjasper.so.4. Downstream builds (Magics) are trying to find the libjasper.so.1 required by ecCodes but don't have it any more. Rebuild ecCodes to update to the latest version of Jasper.

Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
