### PR TITLE
Update build.sh to use lib not lib64

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -23,6 +23,7 @@ mkdir ../build && cd ../build
 
 cmake -D CMAKE_INSTALL_PREFIX=$PREFIX \
       -D CMAKE_BUILD_TYPE=Release \
+      -D INSTALL_LIB_DIR='lib' \
       -D ENABLE_JPG=1 \
       -D ENABLE_NETCDF=1 \
       -D ENABLE_PNG=1 \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - fix-tests-path.patch
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win and vc<14]
   detect_binary_files_with_prefix: true
 


### PR DESCRIPTION
Revert to using lib rather than lib64 to fix python bindings not finding the library.
Later on we will fix the python bindings search mechanism to address this issue

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
