### PR TITLE
Fortran osx arm64

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -15,7 +15,6 @@ if [[ $HOST =~ darwin ]]; then
   export REPLACE_TPL_ABSOLUTE_PATHS=1
   if [[ $HOST =~ arm64 ]]; then
     export MACOS_LE_FLAG="-D IEEE_LE=1"
-    export BUILD_FORTRAN=0
   fi
 elif [[ $HOST =~ linux ]]; then
   export LIBRARY_SEARCH_VAR=LD_LIBRARY_PATH

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   #  - fix-tests-path.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win and vc<14]
   detect_binary_files_with_prefix: true
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
I've just been asked about Fortran bindings on osx-arm64. This was probably disabled because the fortran compiler was not yet available on osx-arm64, but it looks like it should be there now. So this PR is an experiment to see if it now compiles!